### PR TITLE
Button/Popup for users to make edits to their bookings

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,3 +14,4 @@ Use the following code for testing code conventions
 
 `npm run lint`
 
+

--- a/frontend/src/booking/BookingEditPopup.module.css
+++ b/frontend/src/booking/BookingEditPopup.module.css
@@ -1,5 +1,11 @@
 .dialogContainer {
     display: grid;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-column-gap: 10px;
+}
+
+.dialogContainerDetails {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 50px;
 }

--- a/frontend/src/booking/BookingEditPopup.module.css
+++ b/frontend/src/booking/BookingEditPopup.module.css
@@ -1,0 +1,5 @@
+.dialogContainer {
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+    grid-column-gap: 10px;
+}

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -4,11 +4,15 @@ import Button from '@material-ui/core/Button';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Dialog from '@material-ui/core/Dialog';
 import TextField from '@material-ui/core/TextField';
+import changePath from "../general/helperFunctions";
 import {useHistory} from "react-router";
 
+/**
+ * A button which summons the popup to edit bookings.
+ */
+const BookingEditPopupButton = (props) => {
 
-const BookingEditPopupButton = () => {
-
+    const { IDSwitchMethod } = props;
     const [open, setOpen] = React.useState(false);
 
     const handleClickOpen = () => {
@@ -23,20 +27,22 @@ const BookingEditPopupButton = () => {
         <Button variant="outlined" color="primary" onClick={handleClickOpen}>
             Edit Booking
         </Button>
-        <PopupDialog open={open} onClose={handleClose} />
+        <PopupDialog open={open} onClose={handleClose} IDSwitchMethod={IDSwitchMethod}/>
     </div>);
 }
 
 export default BookingEditPopupButton;
 
 /**
- * The popup itself
+ * The popup itself which is used to edit bookings
  */
 const PopupDialog = (props) => {
 
+    const dummyRestaurant = "KCF";
+
     const history = useHistory();
     const [isInput, changeInput] = React.useState(true)
-    const { onClose, open } = props;
+    const { onClose, open, IDSwitchMethod} = props;
 
     const handleClosePopup = () => {
         onClose();
@@ -54,9 +60,10 @@ const PopupDialog = (props) => {
     };
 
     const handleEditBooking = () => {
-
-        history.push("/booking");
+        IDSwitchMethod(dummyRestaurant);
+        changePath("/booking", history);
     };
+
 
     return (
         (isInput) ?

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Dialog from '@material-ui/core/Dialog';
+import TextField from '@material-ui/core/TextField';
+import { blue } from '@material-ui/core/colors';
+import {useHistory} from "react-router";
+
+const BookingEditPopupButton = () => {
+
+    const [open, setOpen] = React.useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return (<div>
+        <Button variant="outlined" color="primary" onClick={handleClickOpen}>
+            Edit Booking
+        </Button>
+        <PopupDialog open={open} onClose={handleClose} />
+    </div>);
+}
+
+
+export default BookingEditPopupButton;
+
+const PopupDialog = (props) => {
+
+    const history = useHistory();
+    const [isInput, changeInput] = React.useState(true)
+
+    const { onClose, open } = props;
+
+    const handleClose = () => {
+        onClose();
+        handleChangeInputTrue();
+    };
+
+    const handleChangeInputFalse = () => {
+        changeInput(false);
+    };
+
+    const handleChangeInputTrue= () => {
+        changeInput(true);
+    };
+
+    const handleEdit = () => {
+
+        history.push("/booking");
+    };
+
+
+    return (
+        (isInput) ?
+        <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
+
+            <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
+            <TextField id="outlined-basic" label="Insert ID here" variant="outlined" />
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClose}>
+                Cancel
+            </Button>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeInputFalse}>
+                Confirm
+            </Button>
+
+
+        </Dialog> :
+        <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
+            <div>
+                <p>
+                    You have booked 1 table for 4 people at KCF
+                </p>
+            </div>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEdit}>
+                Edit
+            </Button>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClose}>
+                OK
+            </Button>
+
+        </Dialog>
+    );
+}
+
+PopupDialog.propTypes = {
+    onClose: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+};
+
+
+

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Dialog from '@material-ui/core/Dialog';
 import TextField from '@material-ui/core/TextField';
-import { blue } from '@material-ui/core/colors';
 import {useHistory} from "react-router";
 
 
@@ -29,64 +27,62 @@ const BookingEditPopupButton = () => {
     </div>);
 }
 
-
 export default BookingEditPopupButton;
 
+/**
+ * The popup itself
+ */
 const PopupDialog = (props) => {
 
     const history = useHistory();
     const [isInput, changeInput] = React.useState(true)
-
     const { onClose, open } = props;
 
-    const handleClose = () => {
+    const handleClosePopup = () => {
         onClose();
-        setTimeout(function() {
-            handleChangeInputTrue();
-        }, 200);
-
+        //wait for animation to finish
+        resetPopup();
     };
 
-    const handleChangeInputFalse = () => {
+    const handleChangeToBookingDetails = () => {
         changeInput(false);
+
     };
 
-    const handleChangeInputTrue= () => {
+    const resetPopup = () => {
         changeInput(true);
     };
 
-    const handleEdit = () => {
+    const handleEditBooking = () => {
 
         history.push("/booking");
     };
 
-
     return (
         (isInput) ?
-        <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
-
+        <Dialog onClose={handleClosePopup} transitionDuration={0} aria-labelledby="simple-dialog-title" open={open}>
 
             <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
             <TextField id="outlined-basic" label="Insert ID here" variant="outlined" />
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClose}>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
                 Cancel
             </Button>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeInputFalse}>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeToBookingDetails}>
                 Confirm
             </Button>
 
 
         </Dialog> :
-        <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
+        <Dialog onClose={handleClosePopup} aria-labelledby="simple-dialog-title" open={open}>
             <div>
                 <p>
                     You have booked 1 table for 4 people at KCF
                 </p>
             </div>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEdit}>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEditBooking}>
                 Edit
             </Button>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClose}>
+            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
                 OK
             </Button>
 
@@ -96,7 +92,7 @@ const PopupDialog = (props) => {
 
 PopupDialog.propTypes = {
     onClose: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
+    open: PropTypes.bool.isRequired
 };
 
 

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -1,132 +1,41 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Button from '@material-ui/core/Button';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Dialog from '@material-ui/core/Dialog';
-import TextField from '@material-ui/core/TextField';
-import changePath from "../general/helperFunctions";
-import {useHistory} from "react-router";
+import React from "react";
+import Button from "@material-ui/core/Button";
+import { styled } from "@material-ui/core/styles";
+import BookingEditPopupDialog from "./BookingEditPopupDialog";
+import textHolder from "../general/textHolder";
+import css from "./BookingEditPopupCSS";
 
 /**
  * A button which summons the popup to edit bookings.
  */
 const BookingEditPopupButton = (props) => {
+  const { IDSwitchMethod } = props;
+  const [open, setOpen] = React.useState(false);
 
-    const { IDSwitchMethod } = props;
-    const [open, setOpen] = React.useState(false);
+  const PopupButton = styled(Button)(css.button);
 
-    /**
+  /**
      * Opens the popup
      */
-    const handleClickOpen = () => {
-        setOpen(true);
-    };
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
 
-    /**
+  /**
      * Hides the popup
      */
-    const handleClose = () => {
-        setOpen(false);
-    };
+  const handleClose = () => {
+    setOpen(false);
+  };
 
-    return (<div>
-        <Button variant="outlined" color="primary" onClick={handleClickOpen}>
-            Edit Booking
-        </Button>
-        <PopupDialog open={open} onClose={handleClose} IDSwitchMethod={IDSwitchMethod}/>
-    </div>);
-}
-
-export default BookingEditPopupButton;
-
-/**
- * The popup itself which is used to edit bookings
- */
-const PopupDialog = (props) => {
-    // Setup dummy data
-    const dummyBooking = {
-        name: "KCF",
-        tables: 1,
-        people: 4,
-        notes: "Window table please"
-    };
-
-    const history = useHistory();
-    const [isInput, changeInput] = React.useState(true)
-    const { onClose, open, IDSwitchMethod} = props;
-
-    /**
-     * Closes the popup
-     */
-    const handleClosePopup = () => {
-        onClose();
-        // Wait for animation to finish
-        resetPopup();
-    };
-
-    /**
-     * Switches popup to show booking details
-     */
-    const handleChangeToBookingDetails = () => {
-        changeInput(false);
-
-    };
-
-    /**
-     * Resets popup to default state
-     */
-    const resetPopup = () => {
-        changeInput(true);
-    };
-
-    /**
-     * Switches page to the specified restaurant booking page
-     */
-    const handleEditBooking = () => {
-        IDSwitchMethod(dummyBooking.name);
-        changePath("/booking", history);
-    };
-
-
-    return (
-        (isInput) ?
-        <Dialog onClose={handleClosePopup} transitionDuration={0} aria-labelledby="simple-dialog-title" open={open}>
-
-            <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
-            <TextField id="outlined-basic" label="Insert ID here" variant="outlined" />
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
-                Cancel
-            </Button>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeToBookingDetails}>
-                Confirm
-            </Button>
-
-
-        </Dialog> :
-        <Dialog onClose={handleClosePopup} aria-labelledby="simple-dialog-title" open={open}>
-            <div>
-                <p>
-                    You have booked <b>{dummyBooking.tables}</b> table(s) for <b>{dummyBooking.people}</b> people at
-                     "<b>{dummyBooking.name}</b>"!!<br />
-                    You have given the extra notes:<br />
-                    <b>{dummyBooking.notes}</b>
-                </p>
-            </div>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEditBooking}>
-                Edit
-            </Button>
-            <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
-                OK
-            </Button>
-
-        </Dialog>
-    );
-}
-
-PopupDialog.propTypes = {
-    onClose: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired
+  return (
+    <div>
+      <PopupButton variant="outlined" color="primary" onClick={handleClickOpen}>
+        {textHolder.bookingsPopup.buttonText}
+      </PopupButton>
+      <BookingEditPopupDialog open={open} onClose={handleClose} IDSwitchMethod={IDSwitchMethod} />
+    </div>
+  );
 };
 
-
-
+export default BookingEditPopupButton;

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -15,10 +15,16 @@ const BookingEditPopupButton = (props) => {
     const { IDSwitchMethod } = props;
     const [open, setOpen] = React.useState(false);
 
+    /**
+     * Opens the popup
+     */
     const handleClickOpen = () => {
         setOpen(true);
     };
 
+    /**
+     * Hides the popup
+     */
     const handleClose = () => {
         setOpen(false);
     };
@@ -37,30 +43,47 @@ export default BookingEditPopupButton;
  * The popup itself which is used to edit bookings
  */
 const PopupDialog = (props) => {
-
-    const dummyRestaurant = "KCF";
+    // Setup dummy data
+    const dummyBooking = {
+        name: "KCF",
+        tables: 1,
+        people: 4,
+        notes: "Window table please"
+    };
 
     const history = useHistory();
     const [isInput, changeInput] = React.useState(true)
     const { onClose, open, IDSwitchMethod} = props;
 
+    /**
+     * Closes the popup
+     */
     const handleClosePopup = () => {
         onClose();
         // Wait for animation to finish
         resetPopup();
     };
 
+    /**
+     * Switches popup to show booking details
+     */
     const handleChangeToBookingDetails = () => {
         changeInput(false);
 
     };
 
+    /**
+     * Resets popup to default state
+     */
     const resetPopup = () => {
         changeInput(true);
     };
 
+    /**
+     * Switches page to the specified restaurant booking page
+     */
     const handleEditBooking = () => {
-        IDSwitchMethod(dummyRestaurant);
+        IDSwitchMethod(dummyBooking.name);
         changePath("/booking", history);
     };
 
@@ -83,7 +106,10 @@ const PopupDialog = (props) => {
         <Dialog onClose={handleClosePopup} aria-labelledby="simple-dialog-title" open={open}>
             <div>
                 <p>
-                    You have booked 1 table for 4 people at KCF
+                    You have booked <b>{dummyBooking.tables}</b> table(s) for <b>{dummyBooking.people}</b> people at
+                     "<b>{dummyBooking.name}</b>"!!<br />
+                    You have given the extra notes:<br />
+                    <b>{dummyBooking.notes}</b>
                 </p>
             </div>
             <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEditBooking}>

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -8,6 +8,7 @@ import TextField from '@material-ui/core/TextField';
 import { blue } from '@material-ui/core/colors';
 import {useHistory} from "react-router";
 
+
 const BookingEditPopupButton = () => {
 
     const [open, setOpen] = React.useState(false);
@@ -40,7 +41,10 @@ const PopupDialog = (props) => {
 
     const handleClose = () => {
         onClose();
-        handleChangeInputTrue();
+        setTimeout(function() {
+            handleChangeInputTrue();
+        }, 200);
+
     };
 
     const handleChangeInputFalse = () => {
@@ -60,6 +64,7 @@ const PopupDialog = (props) => {
     return (
         (isInput) ?
         <Dialog onClose={handleClose} aria-labelledby="simple-dialog-title" open={open}>
+
 
             <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
             <TextField id="outlined-basic" label="Insert ID here" variant="outlined" />

--- a/frontend/src/booking/BookingEditPopupButton.js
+++ b/frontend/src/booking/BookingEditPopupButton.js
@@ -46,7 +46,7 @@ const PopupDialog = (props) => {
 
     const handleClosePopup = () => {
         onClose();
-        //wait for animation to finish
+        // Wait for animation to finish
         resetPopup();
     };
 

--- a/frontend/src/booking/BookingEditPopupCSS.js
+++ b/frontend/src/booking/BookingEditPopupCSS.js
@@ -1,0 +1,14 @@
+import color from "../general/colorScheme";
+
+/**
+ * Stores the stylesheet for booking edit popup components
+ * @type {{}}
+ */
+const css = {
+  button: {
+    background: color.primary,
+  },
+
+};
+
+export default css;

--- a/frontend/src/booking/BookingEditPopupDialog.js
+++ b/frontend/src/booking/BookingEditPopupDialog.js
@@ -5,8 +5,11 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import TextField from "@material-ui/core/TextField";
 import Button from "@material-ui/core/Button";
 import PropTypes from "prop-types";
+import { styled } from "@material-ui/core";
+import style from "./BookingEditPopup.module.css";
 import changePath from "../general/helperFunctions";
 import textHolder from "../general/textHolder";
+import css from "./BookingEditPopupCSS";
 
 /**
  * The popup itself which is used to edit bookings
@@ -25,6 +28,7 @@ const BookingEditPopupDialog = (props) => {
   const [isError, changeError] = React.useState(false);
   const [bookingID, changeBookingID] = React.useState("");
   const { onClose, open, IDSwitchMethod } = props;
+  const PopupButton = styled(Button)(css.button);
 
   /**
      * Resets popup to default state
@@ -32,6 +36,7 @@ const BookingEditPopupDialog = (props) => {
   const resetPopup = () => {
     changeInput(true);
     changeError(false);
+    changeBookingID("");
   };
 
   /**
@@ -62,31 +67,35 @@ const BookingEditPopupDialog = (props) => {
     changePath("/booking", history);
   };
 
-
   return (
     (isInput)
       ? (
         <Dialog onClose={handleClosePopup} transitionDuration={0} aria-labelledby="simple-dialog-title" open={open}>
-
-          <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
-          {(!isError) ? (
-            <TextField id="outlined-basic" label="Insert ID here" variant="outlined" onChange={changeBookingID} />
-          ) : (
-            <TextField
-              error
-              id="outlined-basic"
-              helperText="Cannot be Empty"
-              label="Insert ID here"
-              variant="outlined"
-              onChange={changeBookingID}
-            />
-          )}
-          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
-            {textHolder.bookingsPopup.popupCancel}
-          </Button>
-          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeToBookingDetails}>
-            {textHolder.bookingsPopup.popupConfirm}
-          </Button>
+          <div>
+            <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
+            <div>
+              {(!isError) ? (
+                <TextField id="outlined-basic" label="Insert ID here" variant="outlined" onChange={changeBookingID} />
+              ) : (
+                <TextField
+                  error
+                  id="outlined-basic"
+                  helperText="Cannot be Empty"
+                  label="Insert ID here"
+                  variant="outlined"
+                  onChange={changeBookingID}
+                />
+              )}
+            </div>
+            <div className={style.dialogContainer}>
+              <PopupButton variant="outlined" fullWidth={false} onClick={handleClosePopup}>
+                {textHolder.bookingsPopup.popupCancel}
+              </PopupButton>
+              <PopupButton variant="outlined" fullWidth={false} onClick={handleChangeToBookingDetails}>
+                {textHolder.bookingsPopup.popupConfirm}
+              </PopupButton>
+            </div>
+          </div>
         </Dialog>
       )
       : (
@@ -110,13 +119,14 @@ const BookingEditPopupDialog = (props) => {
               <b>{dummyBooking.notes}</b>
             </p>
           </div>
-          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEditBooking}>
-            {textHolder.bookingsPopup.popupEdit}
-          </Button>
-          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
-            {textHolder.bookingsPopup.popupOK}
-          </Button>
-
+          <div>
+            <PopupButton variant="outlined" fullWidth={false} onClick={handleEditBooking}>
+              {textHolder.bookingsPopup.popupEdit}
+            </PopupButton>
+            <PopupButton variant="outlined" fullWidth={false} onClick={handleClosePopup}>
+              {textHolder.bookingsPopup.popupOK}
+            </PopupButton>
+          </div>
         </Dialog>
       )
   );

--- a/frontend/src/booking/BookingEditPopupDialog.js
+++ b/frontend/src/booking/BookingEditPopupDialog.js
@@ -1,0 +1,130 @@
+import { useHistory } from "react-router";
+import React from "react";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import TextField from "@material-ui/core/TextField";
+import Button from "@material-ui/core/Button";
+import PropTypes from "prop-types";
+import changePath from "../general/helperFunctions";
+import textHolder from "../general/textHolder";
+
+/**
+ * The popup itself which is used to edit bookings
+ */
+const BookingEditPopupDialog = (props) => {
+  // Setup dummy data
+  const dummyBooking = {
+    name: "KCF",
+    tables: 1,
+    people: 4,
+    notes: "Window table please",
+  };
+
+  const history = useHistory();
+  const [isInput, changeInput] = React.useState(true);
+  const [isError, changeError] = React.useState(false);
+  const [bookingID, changeBookingID] = React.useState("");
+  const { onClose, open, IDSwitchMethod } = props;
+
+  /**
+     * Resets popup to default state
+    */
+  const resetPopup = () => {
+    changeInput(true);
+    changeError(false);
+  };
+
+  /**
+     * Closes the popup
+     */
+  const handleClosePopup = () => {
+    onClose();
+    // Wait for animation to finish
+    resetPopup();
+  };
+
+  /**
+     * Switches popup to show booking details
+     */
+  const handleChangeToBookingDetails = () => {
+    if (bookingID.length !== 0) {
+      changeInput(false);
+    } else {
+      changeError(true);
+    }
+  };
+
+  /**
+     * Switches page to the specified restaurant booking page
+     */
+  const handleEditBooking = () => {
+    IDSwitchMethod(dummyBooking.name);
+    changePath("/booking", history);
+  };
+
+
+  return (
+    (isInput)
+      ? (
+        <Dialog onClose={handleClosePopup} transitionDuration={0} aria-labelledby="simple-dialog-title" open={open}>
+
+          <DialogTitle id="simple-dialog-title">Input Booking ID</DialogTitle>
+          {(!isError) ? (
+            <TextField id="outlined-basic" label="Insert ID here" variant="outlined" onChange={changeBookingID} />
+          ) : (
+            <TextField
+              error
+              id="outlined-basic"
+              helperText="Cannot be Empty"
+              label="Insert ID here"
+              variant="outlined"
+              onChange={changeBookingID}
+            />
+          )}
+          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
+            {textHolder.bookingsPopup.popupCancel}
+          </Button>
+          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleChangeToBookingDetails}>
+            {textHolder.bookingsPopup.popupConfirm}
+          </Button>
+        </Dialog>
+      )
+      : (
+        <Dialog onClose={handleClosePopup} aria-labelledby="simple-dialog-title" open={open}>
+          <div>
+            <p>
+              You have booked&nbsp;
+              {" "}
+              <b>{dummyBooking.tables}</b>
+              {" "}
+              table(s) for&nbsp;
+              <b>{dummyBooking.people}</b>
+              {" "}
+              people at&nbsp;
+              &quot;
+              <b>{dummyBooking.name}</b>
+              &quot;!!
+              <br />
+              You have given the extra notes:
+              <br />
+              <b>{dummyBooking.notes}</b>
+            </p>
+          </div>
+          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleEditBooking}>
+            {textHolder.bookingsPopup.popupEdit}
+          </Button>
+          <Button variant="outlined" color="primary" fullWidth={false} onClick={handleClosePopup}>
+            {textHolder.bookingsPopup.popupOK}
+          </Button>
+
+        </Dialog>
+      )
+  );
+};
+
+BookingEditPopupDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+export default BookingEditPopupDialog;

--- a/frontend/src/booking/BookingEditPopupDialog.js
+++ b/frontend/src/booking/BookingEditPopupDialog.js
@@ -119,7 +119,7 @@ const BookingEditPopupDialog = (props) => {
               <b>{dummyBooking.notes}</b>
             </p>
           </div>
-          <div>
+          <div className={style.dialogContainerDetails}>
             <PopupButton variant="outlined" fullWidth={false} onClick={handleEditBooking}>
               {textHolder.bookingsPopup.popupEdit}
             </PopupButton>

--- a/frontend/src/general/colorScheme.js
+++ b/frontend/src/general/colorScheme.js
@@ -1,0 +1,11 @@
+/**
+ * A place to hold the colours used across the application
+ * @type {{}}
+ */
+const colour = {
+  primary: "White",
+  secondary: "Purple",
+  hoverSelect: "#D3D3D3", // Light Grey
+};
+
+export default colour;

--- a/frontend/src/general/textHolder.js
+++ b/frontend/src/general/textHolder.js
@@ -22,9 +22,17 @@ const messages = {
     buttonNextText: "Finish",
     confirmText: "Number: 12123 blah blah",
   },
+  bookingsPopup: {
+    buttonText: "Edit Booking",
+    popupCancel: "Cancel",
+    popupConfirm: "Confirm",
+    popupEdit: "Edit",
+    popupOK: "OK",
+  },
   notFound: {
     message: "404 NOT FOUND",
   },
+
 };
 
 export default messages;

--- a/frontend/src/landing/LandingPage.js
+++ b/frontend/src/landing/LandingPage.js
@@ -10,6 +10,7 @@ const landingText = messages.landingPage;
 const LandingPage = (props) => {
   const { setRestaurant } = props;
   const history = useHistory();
+
   const toBooking = (restaurant) => {
     changePath("/booking", history);
     setRestaurant(restaurant);
@@ -29,7 +30,7 @@ const LandingPage = (props) => {
   return (
     <div className={style.landingPageContainer}>
       <div>
-          <BookingEditPopupButton></BookingEditPopupButton>
+          <BookingEditPopupButton IDSwitchMethod={toBooking} />
       </div>
       <div className={style.header}>
         {landingText.header}

--- a/frontend/src/landing/LandingPage.js
+++ b/frontend/src/landing/LandingPage.js
@@ -5,6 +5,7 @@ import changePath from "../general/helperFunctions";
 import messages from "../general/textHolder";
 import BookingEditPopupButton from "../booking/BookingEditPopupButton";
 
+
 const landingText = messages.landingPage;
 
 const LandingPage = (props) => {
@@ -29,14 +30,12 @@ const LandingPage = (props) => {
 
   return (
     <div className={style.landingPageContainer}>
-      <div>
-          <BookingEditPopupButton IDSwitchMethod={toBooking} />
-      </div>
       <div className={style.header}>
         {landingText.header}
       </div>
       <div className={style.searchContainer}>
         {landingText.search}
+        <BookingEditPopupButton IDSwitchMethod={toBooking} />
       </div>
       <div className={style.tileContainer}>
         { fakeData.map((data) => (

--- a/frontend/src/landing/LandingPage.js
+++ b/frontend/src/landing/LandingPage.js
@@ -3,6 +3,7 @@ import { useHistory } from "react-router";
 import style from "./LandingPage.module.css";
 import changePath from "../general/helperFunctions";
 import messages from "../general/textHolder";
+import BookingEditPopupButton from "../booking/BookingEditPopupButton";
 
 const landingText = messages.landingPage;
 
@@ -27,6 +28,9 @@ const LandingPage = (props) => {
 
   return (
     <div className={style.landingPageContainer}>
+      <div>
+          <BookingEditPopupButton></BookingEditPopupButton>
+      </div>
       <div className={style.header}>
         {landingText.header}
       </div>


### PR DESCRIPTION
## Link to Issue Number
closes #32 


## Description
Created a button/popup which would allow the user to edit existing bookings. This currently has no functionality (uses dummy data), but can be changed to use actual data when API is online. It takes in the booking ID number, and allows a user to change the details of that booking.

## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all nessisary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned at least two people to review my changes


## Other Notes
Test(s) ran had complete coverage - until further tests became trivial
The popup has functionality but basic aesthetic design, awaiting on further confirmation for design. 
