### PR TITLE
Add page to enter booking details and save these details in state

### DIFF
--- a/frontend/src/booking/BookingPage.js
+++ b/frontend/src/booking/BookingPage.js
@@ -30,7 +30,7 @@ const BookingPage = (props) => {
               <Switch>
                 <Route path="/details" component={() => <DetailsContainer />} />
                 <Route path="/confirmation" component={() => <ConfirmationContainer browserHistory={history} />} />
-                <Route path="/" component={() => <TimeContainer />} />
+                <Route path="/" component={() => <DetailsContainer />} />
               </Switch>
             </Router>
           </>

--- a/frontend/src/booking/BookingPage.js
+++ b/frontend/src/booking/BookingPage.js
@@ -6,7 +6,6 @@ import {
 } from "react-router";
 import style from "./BookingPage.module.css";
 import NotFound from "../general/NotFound";
-import TimeContainer from "./TimeContainer";
 import DetailsContainer from "./DetailsContainer";
 import ConfirmationContainer from "./ConfirmationContainer";
 

--- a/frontend/src/booking/BookingPage.module.css
+++ b/frontend/src/booking/BookingPage.module.css
@@ -2,3 +2,11 @@
     height: 100%;
     width: 100%;
 }
+
+.bookingDetailsContainer {
+    text-align: center;
+}
+
+.bookingDetial {
+    display: inline-block;
+}

--- a/frontend/src/booking/ConfirmationContainer.js
+++ b/frontend/src/booking/ConfirmationContainer.js
@@ -9,7 +9,11 @@ const ConfirmationContainer = (props) => {
   const { browserHistory, numberOfSeats } = props;
   return (
     <div>
+<<<<<<< HEAD
       {/* TODO: Just a placeholder, edit later */}
+=======
+      {/* TODO: Delete later */}
+>>>>>>> Set up base statement management with Redux
       <p>{`NUMBER OF SEATS: ${numberOfSeats}`}</p>
       {confirmationMessages.confirmText}
       <button onClick={() => changePath("/", browserHistory)}>{confirmationMessages.buttonNextText}</button>

--- a/frontend/src/booking/ConfirmationContainer.js
+++ b/frontend/src/booking/ConfirmationContainer.js
@@ -9,11 +9,7 @@ const ConfirmationContainer = (props) => {
   const { browserHistory, numberOfSeats } = props;
   return (
     <div>
-<<<<<<< HEAD
       {/* TODO: Just a placeholder, edit later */}
-=======
-      {/* TODO: Delete later */}
->>>>>>> Set up base statement management with Redux
       <p>{`NUMBER OF SEATS: ${numberOfSeats}`}</p>
       {confirmationMessages.confirmText}
       <button onClick={() => changePath("/", browserHistory)}>{confirmationMessages.buttonNextText}</button>

--- a/frontend/src/booking/DetailsContainer.js
+++ b/frontend/src/booking/DetailsContainer.js
@@ -1,18 +1,51 @@
 import React from "react";
 import { useHistory } from "react-router";
 import style from "./BookingPage.module.css";
+import { TextField } from "@material-ui/core";
+import { KeyboardDatePicker, MuiPickersUtilsProvider  } from '@material-ui/pickers';
+import DateFnsUtils from '@date-io/date-fns';
 import changePath from "../general/helperFunctions";
+import TimeContainer from "./TimeContainer";
 import messages from "../general/textHolder";
 
 const detailMessages = messages.details;
 const DetailsContainer = () => {
   const history = useHistory();
 
+  const [selectedDate, setSelectedDate] = React.useState(new Date());
+
+  const handleDateChange = date => {
+    setSelectedDate(date);
+  };
+
   return (
     <div className={style.contentContainer}>
-      {/* Input fields go here */}
-      <div className={style.inputContainer}>{detailMessages.placeholder}</div>
-      <div className={style.timeContainer} />
+      <div>{detailMessages.placeholder}</div>
+      <div className={style.inputContainer}>
+        <div>
+          <TextField
+            label="Number of Guests"
+            variant="outlined"
+          />
+        </div>
+        <div>
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <KeyboardDatePicker
+              disableToolbar
+              inputVariant="outlined"
+              format="dd/MM/yyyy"
+              margin="normal"
+              label="Select a Date"
+              value={selectedDate}
+              onChange={handleDateChange}
+              KeyboardButtonProps={{
+                'aria-label': 'change date',
+              }}
+            />
+          </MuiPickersUtilsProvider>
+        </div>
+      </div>
+      <TimeContainer />
       <div className={style.buttonContainer}>
         <button onClick={() => changePath("/", history)}>{detailMessages.buttonBackText}</button>
         <button onClick={() => changePath("/confirmation", history)}>{detailMessages.buttonNextText}</button>

--- a/frontend/src/booking/DetailsContainer.js
+++ b/frontend/src/booking/DetailsContainer.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useHistory } from "react-router";
+import { connect } from "react-redux";
 import style from "./BookingPage.module.css";
 import { TextField } from "@material-ui/core";
 import { KeyboardDatePicker, MuiPickersUtilsProvider  } from '@material-ui/pickers';
@@ -7,28 +8,36 @@ import DateFnsUtils from '@date-io/date-fns';
 import changePath from "../general/helperFunctions";
 import TimeContainer from "./TimeContainer";
 import messages from "../general/textHolder";
+import { addBooking } from "../store/booking/bookingActions";
 
 const detailMessages = messages.details;
-const DetailsContainer = () => {
+const DetailsContainer = (props) => {
   const history = useHistory();
 
-  const [selectedDate, setSelectedDate] = React.useState(new Date());
+  const [seats, changeSeats] = React.useState((props.seats == null) ? "" : props.seats);
+  const [selectedDate, setSelectedDate] = React.useState((props.date == null) ? new Date() : props.date);
 
-  const handleDateChange = date => {
+  const handleDateChange = (date) => {
     setSelectedDate(date);
   };
 
+  const handleConfirmBooking = () => {
+    changePath("/confirmation", history);
+    props.onConfirmClick(selectedDate, seats, null);
+  }
+
   return (
-    <div className={style.contentContainer}>
+    <div className={style.bookingDetailsContainer}>
       <div>{detailMessages.placeholder}</div>
-      <div className={style.inputContainer}>
-        <div>
+      <div className={style.bookingDetailsContainer}>
+        <div className={style.bookingDetail}>
           <TextField
             label="Number of Guests"
             variant="outlined"
+            onChance={changeSeats}
           />
         </div>
-        <div>
+        <div className={style.bookingDetail}>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
             <KeyboardDatePicker
               disableToolbar
@@ -48,10 +57,20 @@ const DetailsContainer = () => {
       <TimeContainer />
       <div className={style.buttonContainer}>
         <button onClick={() => changePath("/", history)}>{detailMessages.buttonBackText}</button>
-        <button onClick={() => changePath("/confirmation", history)}>{detailMessages.buttonNextText}</button>
+        <button onClick={handleConfirmBooking}>{detailMessages.buttonNextText}</button>
       </div>
     </div>
   );
 };
 
-export default DetailsContainer;
+const mapStateToProps = (state) => ({
+  seats: state.bookingReducer.seats,
+  date: state.bookingReducer.date,
+  time: state.bookingReducer.time,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  onConfirmClick: (date, seats, time) => { dispatch(addBooking(date, seats, time, "", null))}
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DetailsContainer);

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router";
 import { TextField } from "@material-ui/core";
 import { connect } from "react-redux";
 import style from "./BookingPage.module.css";
-import changePath from "../general/helperFunctions";
 import messages from "../general/textHolder";
 import { updateSeats } from "../store/booking/bookingActions";
 
@@ -12,15 +10,10 @@ const timeMessages = messages.time;
 
 const TimeContainer = (props) => {
   const [seatsNumber, handleSeatsNumber] = useState("");
-  const history = useHistory();
 
   /**
    * Upon clicking, we want to update the store with inputted values
    */
-  const handleButtonClick = () => {
-    changePath("/details", history);
-    props.onButtonClick(seatsNumber);
-  };
   return (
     <div className={style.contentContainer}>
       {/* Input fields go here */}

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -28,6 +28,7 @@ const TimeContainer = (props) => {
       <div className={style.inputContainer}>
         <TextField
           type="number"
+          variant="outlined"
           value={seatsNumber}
           onChange={
             (e) => { handleSeatsNumber(e.target.value); }
@@ -35,10 +36,6 @@ const TimeContainer = (props) => {
         />
       </div>
       <div className={style.timeContainer} />
-      <div className={style.buttonContainer}>
-        {/* We will have to store things onClick */}
-        <button onClick={() => handleButtonClick(history)}>{timeMessages.buttonNextText}</button>
-      </div>
     </div>
   );
 };

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -29,13 +29,6 @@ const TimeContainer = (props) => {
         />
       </div>
       <div className={style.timeContainer} />
-<<<<<<< HEAD
-=======
-      <div className={style.buttonContainer}>
-        {/* We will have to store things onClick */}
-      </div>
-      <div className={style.timeContainer} />
->>>>>>> 68d18553ed3aaa32ef34c7a09329e97b061d2a8e
     </div>
   );
 };

--- a/frontend/src/general/textHolder.js
+++ b/frontend/src/general/textHolder.js
@@ -10,9 +10,9 @@ const messages = {
     footer: "Footer",
   },
   details: {
-    buttonNextText: "Done",
+    buttonNextText: "Next",
     buttonBackText: "Back",
-    placeholder: "AT DETAILS",
+    placeholder: "Booking Details",
   },
   time: {
     buttonNextText: "Next",

--- a/frontend/src/store/booking/bookingActions.js
+++ b/frontend/src/store/booking/bookingActions.js
@@ -1,5 +1,6 @@
 export const actionType = {
   SEAT_BOOKING: "SEAT_BOOKING",
+  ADD_BOOKING: "ADD_BOOKING",
 };
 
 const updateSeats = (numberOfSeats) => ({
@@ -7,6 +8,16 @@ const updateSeats = (numberOfSeats) => ({
   numberOfSeats,
 });
 
+const addBooking = (date, seats, time, notes, bookingID) => ({
+  type: actionType.ADD_BOOKING,
+  date,
+  seats,
+  time,
+  notes,
+  bookingID,
+})
+
 export {
   updateSeats,
+  addBooking,
 };

--- a/frontend/src/store/booking/bookingReducer.js
+++ b/frontend/src/store/booking/bookingReducer.js
@@ -2,6 +2,11 @@ import { actionType } from "./bookingActions";
 
 const initialState = {
   numberOfSeats: null,
+  date: null,
+  seats: null,
+  time: null,
+  notes: null,
+  bookingID: null,
 };
 
 /**
@@ -21,6 +26,15 @@ const bookingReducer = (state, action) => {
         ...state,
         numberOfSeats: action.numberOfSeats,
       };
+    case actionType.ADD_BOOKING:
+      return {
+        ...state,
+        date: action.date,
+        seats: action.seats,
+        time: action.time,
+        notes: action.notes,
+        bookingID: action.bookingID,
+      }
     default:
       return {
         ...state,


### PR DESCRIPTION
## Link to Issue Number
closes #41 

## Description
Set up the booking details page where a user can enter their desired time, date and number of guests. The date and number of guests are set up completely and are save in the redux store. The time is not yet implemented and will be done so by @mmir415 when the TimeContainer is implemented. These changes use the material ui pickers and date io packages.


## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all necessary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned atleast two people to review my changes


## Other Notes
I am not completely sure how we wanted to save the booking state, so I just made it all done in one methods I am open to suggestions on how better ways to do it because I am pretty unversed in redux. I also haven't added any error checking for the selected date and number of seats, i.e. ensuring the date hasn't already passed. I thought it would be better to get this sanity checking out of the way after more important functionality is complete.