### PR TITLE
Update reservation id generation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7263,6 +7263,11 @@
         "set-value": "^2.0.1"
       }
     },
+    "uniqid": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
+      "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg=="
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,8 @@
     "morgan": "^1.9.1",
     "mysql": "^2.18.1",
     "swagger-jsdoc": "^3.5.0",
-    "swagger-ui-express": "^4.1.3"
+    "swagger-ui-express": "^4.1.3",
+    "uniqid": "^5.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/backend/routes/reservation.js
+++ b/backend/routes/reservation.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import uniqid from 'uniqid';
 
 import connection from '../database';
 
@@ -152,8 +153,8 @@ router.put('/:reservationID', async (req, res) => {
 
 // Add a new reservation when a user wants to book a table.
 router.post('/single', async (req, res) => {
-  // Generate a random number capped at 2147483647 as this is the largest number the database can hold.
-  const reservationID = Math.floor(Math.random() * 2147483647);
+  // Generate a random, unique id.
+  const reservationID = uniqid();
   const { date, time, notes, numberOfGuests, tableID, restaurantID, userID } = req.body;
 
   if (!date || !time || !numberOfGuests || !tableID || !restaurantID || !userID) {

--- a/backend/tests/reservation/postSingle.js
+++ b/backend/tests/reservation/postSingle.js
@@ -26,7 +26,7 @@ describe('POST reservations/single', () => {
 
     const { reservationID, result } = response.body;
     assert.strictEqual(result, 'Added single reservation');
-    assert.isString(reservationID, 'Expected reservationID to be a number');
+    assert.isString(reservationID, 'Expected reservationID to be a string');
   });
 
   it('2. should return expected error when the date parameter is missing.', async () => {
@@ -167,6 +167,6 @@ describe('POST reservations/single', () => {
 
     const { reservationID, result } = response.body;
     assert.strictEqual(result, 'Added single reservation');
-    assert.isString(reservationID, 'Expected reservationID to be a number');
+    assert.isString(reservationID, 'Expected reservationID to be a string');
   });
 });

--- a/backend/tests/reservation/postSingle.js
+++ b/backend/tests/reservation/postSingle.js
@@ -26,7 +26,7 @@ describe('POST reservations/single', () => {
 
     const { reservationID, result } = response.body;
     assert.strictEqual(result, 'Added single reservation');
-    assert.isNumber(reservationID, 'Expected reservationID to be a number');
+    assert.isString(reservationID, 'Expected reservationID to be a number');
   });
 
   it('2. should return expected error when the date parameter is missing.', async () => {
@@ -167,6 +167,6 @@ describe('POST reservations/single', () => {
 
     const { reservationID, result } = response.body;
     assert.strictEqual(result, 'Added single reservation');
-    assert.isNumber(reservationID, 'Expected reservationID to be a number');
+    assert.isString(reservationID, 'Expected reservationID to be a number');
   });
 });


### PR DESCRIPTION
## Link to Issue Number
closes #102 

## Description
As the reservation ID data type was updated to varchar in the database, ids are no longer restricted to numbers.
Replaced manually generating a random number with an id generation package to reduce the chances of duplicate keys being generated.

## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x] I ran all nessisary tests and they pass
- [x] I rebased upstream/master onto my working branch before opening this PR
- [x] I have named my PR something sensible
- [x] I have included the issue number above
- [x] I have assigned atleast two people to review my changes


## Other Notes
No notes.
