### PR TITLE
Disabling of times dependent on date selected and styling

### DIFF
--- a/frontend/src/booking/BookingPage.module.css
+++ b/frontend/src/booking/BookingPage.module.css
@@ -94,6 +94,13 @@
   left: 25%;
 }
 
-.test {
-margin: 2px;
+.buttonContainer {
+  display: grid;
+  /* grid-template-columns: 50px 50px 50px 50px; */
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto;
+  padding-right: 10px;
+  background-color: #4caf50;
+  /* grid-row-gap: 5px; */
+  grid-column-gap: 5px;
 }

--- a/frontend/src/booking/BookingPage.module.css
+++ b/frontend/src/booking/BookingPage.module.css
@@ -93,3 +93,7 @@
   position: absolute;
   left: 25%;
 }
+
+.test {
+margin: 2px;
+}

--- a/frontend/src/booking/BookingPage.module.css
+++ b/frontend/src/booking/BookingPage.module.css
@@ -40,8 +40,9 @@
 .submitbutton {
   background-color: #4caf50; /* Green */
   border: none;
-  color: white;
+  color: #4caf50;
   margin: 15px 32px;
+  padding: 5px;
   text-align: center;
   text-decoration: none;
   display: inline-block;
@@ -99,8 +100,12 @@
   /* grid-template-columns: 50px 50px 50px 50px; */
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto;
-  padding-right: 10px;
+  padding: 5px;
   background-color: #4caf50;
   /* grid-row-gap: 5px; */
-  grid-column-gap: 5px;
+  column-gap: 5px;
+}
+
+.test {
+  background-color: #66bb6a;
 }

--- a/frontend/src/booking/BookingPage.module.css
+++ b/frontend/src/booking/BookingPage.module.css
@@ -107,5 +107,6 @@
 }
 
 .test {
-  background-color: #66bb6a;
+  /* background-color: #66bb6a; */
+  padding:1px;
 }

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -63,7 +63,12 @@ const TimeContainer = (props) => {
       time: "2-3pm",
       color: selectedTime === "2-3pm" ? "secondary" : "primary",
     },
-    { time: "3-4pm", color: selectedTime === "3-4pm" ? "secondary" : "primary" },
+    {
+      time: "3-4pm", color: selectedTime === "3-4pm" ? "secondary" : "primary",
+    },
+    {
+      time: "4-5pm", color: selectedTime === "4-5pm" ? "secondary" : "primary",
+    },
   ];
 
   /**
@@ -100,23 +105,24 @@ const TimeContainer = (props) => {
         </div>
         <div className={style.contentContainer}>
           {/* Time fields go here */}
-          {times.map((time) => (
-            <Button
-              className={style.test}
-              key={`time_button_${time.time}`}
-              variant="contained"
-              value={time.time}
-              color={time.color}
-              onClick={(e) => handleTime(e.currentTarget.value)}
-            >
-              {time.time}
-            </Button>
-          ))}
+          <div className={style.buttonContainer}>
+            {times.map((time) => (
+              <Button
+                key={`time_button_${time.time}`}
+                variant="contained"
+                value={time.time}
+                color={time.color}
+                onClick={(e) => handleTime(e.currentTarget.value)}
+              >
+                {time.time}
+              </Button>
+            ))}
+          </div>
 
-          <div className={style.inputContainer}>
+          {/* <div className={style.inputContainer}>
             <p>Current Selected Time</p>
             {/* <TextField type="string" value={selectedTime} /> */}
-          </div>
+          {/* </div> */}
         </div>
       </div>
       <div className={style.buttonContainer}>

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -108,6 +108,7 @@ const TimeContainer = (props) => {
           <div className={style.buttonContainer}>
             {times.map((time) => (
               <Button
+                className={style.test}
                 key={`time_button_${time.time}`}
                 variant="contained"
                 value={time.time}
@@ -125,10 +126,10 @@ const TimeContainer = (props) => {
           {/* </div> */}
         </div>
       </div>
-      <div className={style.buttonContainer}>
-        <button onClick={handleTimeConfirmation}>
+      <div className={style.submitbutton}>
+        <Button variant="contained" color="#4caf50" onClick={handleTimeConfirmation}>
           {timeMessages.buttonNextText}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -5,6 +5,7 @@ import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
+import { format } from "date-fns";
 import DateFnsUtils from "@date-io/date-fns";
 import { connect } from "react-redux";
 import style from "./BookingPage.module.css";
@@ -36,38 +37,57 @@ const TimeContainer = (props) => {
 
   const handleTime = (value) => {
     setSelectedTime(value);
+    console.log(selectedDate);
+    console.log(format(selectedDate, "yyyy-MM-dd"));
+    console.log(typeof (format(selectedDate, "yyyy-MM-dd")));
+    console.log(typeof (selectedDate));
+    console.log(((format(selectedDate, "yyyy-MM-dd")) === "2020-03-18"));
   };
+
+  // const disabled = true;
+  // const able = false;
+  let formattedDate = ((format(selectedDate, "yyyy-MM-dd")));
 
   const times = [
     {
       time: "9-10am",
       color: selectedTime === "9-10am" ? "secondary" : "primary",
+      disabled: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-18"),
     },
     {
       time: "10-11am",
       color: selectedTime === "10-11am" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-18"),
     },
     {
       time: "11am-12pm",
       color: selectedTime === "11am-12pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-19"),
     },
     {
       time: "12-1pm",
       color: selectedTime === "12-1pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-20"),
     },
     {
       time: "1-2pm",
       color: selectedTime === "1-2pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-20"),
     },
     {
       time: "2-3pm",
       color: selectedTime === "2-3pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-21"),
     },
     {
-      time: "3-4pm", color: selectedTime === "3-4pm" ? "secondary" : "primary",
+      time: "3-4pm",
+      color: selectedTime === "3-4pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-22"),
     },
     {
-      time: "4-5pm", color: selectedTime === "4-5pm" ? "secondary" : "primary",
+      time: "4-5pm",
+      color: selectedTime === "4-5pm" ? "secondary" : "primary",
+      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-23"),
     },
   ];
 
@@ -111,9 +131,13 @@ const TimeContainer = (props) => {
                 className={style.test}
                 key={`time_button_${time.time}`}
                 variant="contained"
+                disabled={time.disabled}
                 value={time.time}
                 color={time.color}
+                // disabled
                 onClick={(e) => handleTime(e.currentTarget.value)}
+              // onClick={console.log(time.disability)}
+
               >
                 {time.time}
               </Button>
@@ -127,7 +151,7 @@ const TimeContainer = (props) => {
         </div>
       </div>
       <div className={style.submitbutton}>
-        <Button variant="contained" color="#4caf50" onClick={handleTimeConfirmation}>
+        <Button variant="contained" color="primary" onClick={handleTimeConfirmation}>
           {timeMessages.buttonNextText}
         </Button>
       </div>

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -37,57 +37,48 @@ const TimeContainer = (props) => {
 
   const handleTime = (value) => {
     setSelectedTime(value);
-    console.log(selectedDate);
-    console.log(format(selectedDate, "yyyy-MM-dd"));
-    console.log(typeof (format(selectedDate, "yyyy-MM-dd")));
-    console.log(typeof (selectedDate));
-    console.log(((format(selectedDate, "yyyy-MM-dd")) === "2020-03-18"));
   };
-
-  // const disabled = true;
-  // const able = false;
-  let formattedDate = ((format(selectedDate, "yyyy-MM-dd")));
 
   const times = [
     {
       time: "9-10am",
       color: selectedTime === "9-10am" ? "secondary" : "primary",
-      disabled: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-18"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-18"),
     },
     {
       time: "10-11am",
       color: selectedTime === "10-11am" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-18"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-19"),
     },
     {
       time: "11am-12pm",
       color: selectedTime === "11am-12pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-19"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-19"),
     },
     {
       time: "12-1pm",
       color: selectedTime === "12-1pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-20"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-20"),
     },
     {
       time: "1-2pm",
       color: selectedTime === "1-2pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-20"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-20"),
     },
     {
       time: "2-3pm",
       color: selectedTime === "2-3pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-21"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-21"),
     },
     {
       time: "3-4pm",
       color: selectedTime === "3-4pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-22"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-22"),
     },
     {
       time: "4-5pm",
       color: selectedTime === "4-5pm" ? "secondary" : "primary",
-      disablity: !!(format(selectedDate, "yyyy-MM-dd")).includes("2020-03-23"),
+      disable: ((format(selectedDate, "yyyy-MM-dd")) === "2020-03-23"),
     },
   ];
 
@@ -131,12 +122,10 @@ const TimeContainer = (props) => {
                 className={style.test}
                 key={`time_button_${time.time}`}
                 variant="contained"
-                disabled={time.disabled}
+                disabled={time.disable}
                 value={time.time}
                 color={time.color}
-                // disabled
                 onClick={(e) => handleTime(e.currentTarget.value)}
-              // onClick={console.log(time.disability)}
 
               >
                 {time.time}

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -66,10 +66,6 @@ const TimeContainer = (props) => {
     { time: "3-4pm", color: selectedTime === "3-4pm" ? "secondary" : "primary" },
   ];
 
-  // const handleColor = value => {
-  //   const colorClass = selectedTime === value ? "secondary" : "primary";
-  //   return colorClass;
-  // };
   /**
    * Upon clicking, we want to update the store with inputted values
    */
@@ -116,63 +112,6 @@ const TimeContainer = (props) => {
               {time.time}
             </Button>
           ))}
-          {/* <Button
-            className={style.test}
-            variant="contained"
-            value="9-10am"
-            color={handleColor(value)}
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            9-10 am
-          </Button> */}
-          {/* <Button
-            variant="contained"
-            value="10-11am"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            10-11 am
-          </Button>
-          <Button
-            variant="contained"
-            value="11am-12pm"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            11am-12pm
-          </Button>
-          <Button
-            variant="contained"
-            value="12-1pm"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            12-1 pm
-          </Button>
-          <Button
-            variant="contained"
-            value="1-2pm"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            1-2 pm
-          </Button>
-          <Button
-            variant="contained"
-            value="2-3pm"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            2-3 pm
-          </Button>
-          <Button
-            variant="contained"
-            value="3-4pm"
-            color="primary"
-            onClick={e => handleTime(e.currentTarget.value)}
-          >
-            3-4 pm
-          </Button> */}
 
           <div className={style.inputContainer}>
             <p>Current Selected Time</p>

--- a/frontend/src/booking/TimeContainer.js
+++ b/frontend/src/booking/TimeContainer.js
@@ -102,7 +102,7 @@ const TimeContainer = (props) => {
           {/* Time fields go here */}
           {times.map((time) => (
             <Button
-              // className={style.test}
+              className={style.test}
               key={`time_button_${time.time}`}
               variant="contained"
               value={time.time}


### PR DESCRIPTION
This Pull Request satisfies the problems raised in #93 


## Description
Added grid styling on the buttons for time selection, as well as converted the Next button to a Material-UI component for stylistic appeal. Most importantly, enabled certain time slots to be unavailable depending on the date the person has selected, preventing them from being clicked on.


## Checklist
- [x] All feature request A/C have been met OR the bug has been fixed
- [x ] I ran all necessary tests and they pass
- [x ] I rebased upstream/master onto my working branch before opening this PR
- [x ] I have named my PR something sensible
- [x ] I have included the issue number above
- [x ] I have assigned at least two people to review my changes


## Other Notes
Currently, the dates that cause unavailability are hardcoded. Will need to be linked with back-end to get available times at a later stage.
